### PR TITLE
Add a new QA dataset: GraphQuestions

### DIFF
--- a/qa.datasets/README.md
+++ b/qa.datasets/README.md
@@ -16,7 +16,8 @@ to analyze:
  * https://github.com/brmson/dataset-factoid-curated for evolution 
  * https://github.com/brmson/dataset-factoid-movies for domain-specific
  * https://github.com/brmson/dataset-factoid-webquestions for a suit
-* GeoQuery, Free917, WebQuestions, SimpleQuestions and QALD
+* GeoQuery, Free917, WebQuestions, SimpleQuestions, GraphQuestions, and QALD
+* https://github.com/ysu1989/GraphQuestions GraphQuestions: compositional and paraphrased questions 
 * http://www-nlp.stanford.edu/software/sempre/
 * https://sites.google.com/site/trecliveqa2015/
 * http://trec.nist.gov/data/qa.html


### PR DESCRIPTION
GraphQuestions is a new dataset for QA on Freebase. Compared with WebQuestions and SImpleQuestions, GraphQuestions provides more compositional questions and also question paraphrases. It's a good dataset for researchers interested in building QA systems capable of answering questions harder than those only involving a single triple.